### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,12 +36,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add CHANGELOG file
 
 ### Changed
+
 - Replace Mocha + Chai with Jest testing framework
 - Upgrade typescript to 4.X
 
 ## [0.1.9] - 2022-01-25
 
 ### Changed
+
 - return only the data for each list item instad of the whole model
 
 ## [0.1.8] - 2022-01-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Types of changes
+
+- `Added` for new features.
+- `Changed` for changes in existing functionality.
+- `Deprecated` for soon-to-be removed features.
+- `Removed` for now removed features.
+- `Fixed` for any bug fixes.
+- `Security` in case of vulnerabilities.
+
 ## [Unreleased]
+
 ### Added
+
+- Add `rimraf` dependency to cleanup dist folder before every dev build
+- Add `getModelHistory` method to the `AngusController` that returns the chain of custody for an asset since issuance
+
 ### Changed
-### Removed
+
+- Show `method` and `metadata` info in the log messages
+
 
 ## [0.2.0-0] - 2023-03-16
 

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
         "npm": ">=5"
     },
     "scripts": {
+        "devbuild": "rimraf dist/ && npm run build",
         "build": "node_modules/.bin/tsc && cp package.json dist/ && cp -r src/types dist/",
         "start": "fabric-chaincode-node start",
         "devstart": "fabric-chaincode-node start --peer.address peer0:7052 --chaincode-id-name 'default:0' --module-path dist/default",
-        "test": "jest"
+        "test": "jest",
+        "testw": "jest --watch"
     },
     "dependencies": {
         "fabric-contract-api": "2.2.1",
@@ -34,6 +36,7 @@
         "@types/yargs": "^13.0.3",
         "jest": "^29.5.0",
         "nyc": "^15.0.0",
+        "rimraf": "^4.4.0",
         "ts-jest": "^29.0.5",
         "ts-node": "^8.5.4",
         "tslint": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "angus-chaincode",
-    "version": "0.2.0-0",
+    "version": "0.2.0-1",
     "description": "Angus chaincode - smart contract framework for HLF",
     "main": "dist/index.js",
     "types": "dist/types/index.d.ts",

--- a/src/lib/controller.ts
+++ b/src/lib/controller.ts
@@ -48,6 +48,7 @@ export class AngusController {
     }
 
     async getModelList(query: object) {
+        this.ctx.getLogger('getModelList').debug('query', query);
         const iterator = await this.ctx.stub.getQueryResult(JSON.stringify(query));
         const allResults = [];
 

--- a/src/lib/controller.ts
+++ b/src/lib/controller.ts
@@ -1,7 +1,8 @@
+import _ from 'lodash';
 import { AngusContext } from './context';
 import { AngusModel } from './model';
-
-import _ from 'lodash';
+import { HistoryItem } from './types';
+import { fabricTimestampToNumber } from './utils';
 
 export class AngusController {
     ctx: AngusContext;
@@ -14,6 +15,7 @@ export class AngusController {
         this.supportedClasses = {};
     }
 
+    // We can't override, modify the composit key creation logic because of the AngusModel.splitKey usage in this file
     createCompositeKey(name: string, keys: string[]) {
         return _.join([name, AngusModel.makeKey(keys)], '.');
     }
@@ -57,12 +59,47 @@ export class AngusController {
                 const strValue = Buffer.from(res.value.value).toString('utf8');
                 let record;
                 try {
-                    record = JSON.parse(strValue);
+                    record = _.get(JSON.parse(strValue), 'data');
                 } catch (err) {
                     this.ctx.getLogger('getModelList').error(err);
                     record = strValue;
                 }
-                allResults.push(record.data);
+                allResults.push(record);
+            }
+            if (res.done) {
+                await iterator.close();
+                return allResults;
+            }
+        }
+    }
+
+    /**
+     * Get History of a single model.
+     * It returns the chain of custody for an asset since issuance.
+     **/
+    async getModelHistory(key: string): Promise<HistoryItem[]> {
+        this.ctx.getLogger('getModelHistory').debug(`Key: ${key}`);
+        let ledgerKey: string = this.createCompositeKey(this.name, AngusModel.splitKey(key));
+        let iterator = await this.ctx.stub.getHistoryForKey(ledgerKey);
+        const allResults = [];
+
+        while (true) {
+            const res = await iterator.next();
+
+            if (res.value && res.value.value.toString()) {
+                let historyItem: HistoryItem = {
+                    txId: res.value.txId,
+                    timestamp: fabricTimestampToNumber(res.value.timestamp),
+                    value: {},
+                };
+                const strValue = Buffer.from(res.value.value).toString('utf8');
+                try {
+                    historyItem.value = _.get(JSON.parse(strValue), 'data');
+                } catch (err) {
+                    this.ctx.getLogger('getModelHistory').error(err);
+                    historyItem.value = strValue;
+                }
+                allResults.push(historyItem);
             }
             if (res.done) {
                 await iterator.close();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,5 @@
+export type HistoryItem = {
+    txId: string;
+    timestamp: number;
+    value: any;
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { Timestamp } from 'fabric-shim';
+
+export function fabricTimestampToNumber(timestamp: Timestamp): any {
+    const milliseconds = (timestamp.seconds.low + timestamp.nanos / 1000000 / 1000) * 1000;
+    return new Date(milliseconds).getTime();
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,7 +1,9 @@
 // TODO: Must be generated!
 
+import { Context, Contract } from 'fabric-contract-api';
+import { HistoryItem } from '../lib/types';
+
 declare module 'angus-chaincode' {
-    import { Context, Contract } from 'fabric-contract-api';
     //@ts-ignore TS2300
     export class AngusContext extends Context {
         constructor();
@@ -42,6 +44,7 @@ declare module 'angus-chaincode' {
         updateModel(model: AngusModel): Promise<void>;
         deleteModel(model: AngusModel): Promise<void>;
         getModelList(query: object): Promise<any[]>;
+        getModelHistory(key: string): Promise<HistoryItem[]>;
         use(modelClass: any): void;
     }
 

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,0 +1,24 @@
+import { Logger } from '../src/lib/logger';
+
+describe('Logger', () => {
+    describe('createInstance', () => {
+        test('should create a logger that could be used to write to the console', () => {
+            Logger.createInstance('debug');
+            Logger.getLogger('LoggerTest1').debug('test');
+            Logger.getLogger('LoggerTest2').info('test');
+            Logger.getLogger('LoggerTest3').warn('test');
+            Logger.getLogger('LoggerTest4').error('test');
+        });
+        test('check format printer', () => {
+            Logger.createInstance('debug');
+            Logger.getLogger('LoggerTest').debug('Test Message - no meta');
+            Logger.getLogger('LoggerTest').debug('Test Message with object metadata', {
+                testMetaObject: 'TestMetadata',
+            });
+            Logger.getLogger('LoggerTest').debug('Test Message with additional string', 'additional String');
+            Logger.getLogger('LoggerTest').debug('Test Message with additional number', 123);
+            Logger.getLogger('LoggerTest').debug('Test Message with additional array', [123, '23']);
+            Logger.getLogger('LoggerTest').debug(JSON.stringify({ test: 'Test Message should be allways a string' }));
+        });
+    });
+});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,12 @@
+import { Timestamp } from 'fabric-shim';
+import Long from 'long';
+import { fabricTimestampToNumber } from '../src/lib/utils';
+
+describe('Utils Tests', () => {
+    describe('fabricTimestampToNumber', () => {
+        test('should return number', () => {
+            const fabricTimestamp: Timestamp = { seconds: Long.fromInt(1234), nanos: 55 };
+            expect(fabricTimestampToNumber(fabricTimestamp)).toEqual(1234000);
+        });
+    });
+});


### PR DESCRIPTION
add `getModelHistory` new method 👈🏽 

with some refactors, improvements

The logger modofication is a so-so solution because we use a global _method variable to give the value to the  print function. It should NOT cause any serious problem but still I don't like to use a global variable even for this. But finally we get the method name in the logs, that helps a lot during debugging, and because giving a method param is required for every log creation finally we get the desired results.

see: `beforeTransaction` and `addRecord`, etc is the new piece of the log message
<img width="329" alt="image" src="https://user-images.githubusercontent.com/3935646/227448874-1574ce2c-ab8f-4438-9852-74a00da0c39a.png">

And we could even give the logger a meta object that will be JSON.parsed and concatenated at the end of the message.
<img width="697" alt="image" src="https://user-images.githubusercontent.com/3935646/227453201-6143deaa-a15d-4e99-a427-7cc1652f0b00.png">

